### PR TITLE
feat: options to hide user stars rating

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -6988,6 +6988,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_show_similar_on_joined" = "Show similar channels on join message";
 "lng_settings_screen_shot_mode" = "Screenshot Mode";
 "lng_settings_restart_hint" = "WARNING: Changing options that are colored in red will take effect only after the app restarts.";
+"lng_settings_hide_star_ratings" = "Hide user star ratings";
 
 "lng_settings_skip_message" = "Skip to next unread chat";
 "lng_settings_skip_message_desc" = "Note: Allow ALT+↑/↓ shortcut to skip to next unread chat";

--- a/Telegram/SourceFiles/core/enhanced_settings.cpp
+++ b/Telegram/SourceFiles/core/enhanced_settings.cpp
@@ -322,7 +322,8 @@ namespace EnhancedSettings {
 		settings.insert(qsl("hide_stories"), false);
 		settings.insert(qsl("recent_display_limit"), 20);
 		settings.insert(qsl("screenshot_mode"), false);
-		
+		settings.insert(qsl("hide_star_ratings"), false);
+
 		auto document = QJsonDocument();
 		document.setObject(settings);
 		file.write(document.toJson(QJsonDocument::Indented));
@@ -380,7 +381,8 @@ namespace EnhancedSettings {
 		settings.insert(qsl("hide_stories"), GetEnhancedBool("hide_stories"));
 		settings.insert(qsl("recent_display_limit"), GetEnhancedInt("recent_display_limit"));
 		settings.insert(qsl("screenshot_mode"), GetEnhancedBool("screenshot_mode"));
-		
+		settings.insert(qsl("hide_star_ratings"), GetEnhancedBool("hide_star_ratings"));
+
 		auto document = QJsonDocument();
 		document.setObject(settings);
 		file.write(document.toJson(QJsonDocument::Indented));

--- a/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
@@ -656,7 +656,7 @@ Cover::Cover(
 	? object_ptr<TopicIconButton>(this, controller, topic)
 	: nullptr)
 , _name(this, _st.name)
-, _starsRating(_peer->isUser()
+, _starsRating(_peer->isUser() && !GetEnhancedBool("hide_star_ratings")
 	? std::make_unique<Ui::StarsRating>(
 		this,
 		_controller->uiShow(),

--- a/Telegram/SourceFiles/settings/settings_enhanced.cpp
+++ b/Telegram/SourceFiles/settings/settings_enhanced.cpp
@@ -629,6 +629,20 @@ namespace Settings {
 			SetEnhancedValue("hide_stories", enabled);
 			EnhancedSettings::Write();
 		}, container->lifetime());
+		
+		AddButtonWithIcon(
+				container,
+				tr::lng_settings_hide_star_ratings(),
+				st::settingsButtonNoIcon
+		)->toggleOn(
+				rpl::single(GetEnhancedBool("hide_star_ratings"))
+		)->toggledValue(
+		) | rpl::filter([](bool enabled) {
+			return (enabled != GetEnhancedBool("hide_star_ratings"));
+		}) | rpl::start_with_next([=](bool enabled) {
+			SetEnhancedValue("hide_star_ratings", enabled);
+			EnhancedSettings::Write();
+		}, container->lifetime());
 
 		auto value = rpl::single(
 				RecentDisplayLimitController::Label(GetEnhancedInt("recent_display_limit"))


### PR DESCRIPTION
This feature comes from [Yukigram](https://github.com/Revincx/yukigram), and is a simple setting on enhanced settings similar to "hide stories" but for the new stars ratings. I find it useful so, here I am contributing