### PR TITLE
Add Flatpak build

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,94 @@
+---
+name: Flatpak Packager
+on:
+  workflow_dispatch: null
+  workflow_run:
+    workflows:
+      - Linux
+    types:
+      - completed
+jobs:
+  flatpak:
+    name: Package 64Gram
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Setup Build Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+      - name: Download Latest Binary Artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: linux.yml
+          name: Telegram
+          repo: frknkrc44/tdesktop-x64
+          workflow_conclusion: success
+      - name: Prepare Assets
+        run: |
+          curl -L https://upload.wikimedia.org/wikipedia/commons/8/82/Telegram_logo.svg -o icon.svg
+          cat <<EOT > org.frknkrc44.Telegram.desktop
+          [Desktop Entry]
+          Name=64Gram
+          GenericName=Telegram Desktop fork
+          GenericName[es]=Cliente no oficial basado en tg Desktop
+          Comment=64Gram Desktop Messenger
+          Comment[es]=Fork de TG Desktop
+          Exec=Telegram -- %u
+          Icon=org.frknkrc44.Telegram
+          Terminal=false
+          Type=Application
+          Categories=Network;InstantMessaging;
+          StartupWMClass=Telegram
+          MimeType=x-scheme-handler/tg;
+          EOT
+      - name: Create Flatpak Manifest
+        run: |
+          cat <<EOF > org.frknkrc44.Telegram.yml
+          app-id: org.frknkrc44.Telegram
+          runtime: org.gnome.Platform
+          runtime-version: '48'
+          sdk: org.gnome.Sdk
+          command: Telegram
+          finish-args:
+            - --share=ipc
+            - --share=network
+            - --socket=wayland
+            - --socket=fallback-x11
+            - --socket=pulseaudio
+            - --device=all
+            - --talk-name=org.freedesktop.Notifications
+            - --talk-name=org.gnome.Mutter.IdleMonitor
+            - --talk-name=org.kde.StatusNotifierWatcher
+            - --talk-name=com.canonical.AppMenu.Registrar
+            - --talk-name=org.sigxcpu.Feedback
+            - --filesystem=home
+            - --unset-env=QT_PLUGIN_PATH
+          modules:
+            - name: telegram-installer
+              buildsystem: simple
+              build-commands:
+                - mkdir -p /app/bin /app/share/applications /app/share/icons/hicolor/scalable/apps/
+                - cp Telegram /app/bin/Telegram
+                - chmod +x /app/bin/Telegram
+                - cp icon.svg /app/share/icons/hicolor/scalable/apps/org.frknkrc44.Telegram.svg
+                - cp org.frknkrc44.Telegram.desktop /app/share/applications/org.frknkrc44.Telegram.desktop
+              sources:
+                - type: file
+                  path: Telegram
+                - type: file
+                  path: icon.svg
+                - type: file
+                  path: org.frknkrc44.Telegram.desktop
+          EOF
+      - name: Build Flatpak Bundle
+        run: |
+          flatpak-builder --user --install-deps-from=flathub --disable-rofiles-fuse --force-clean --repo=repo build_dir org.frknkrc44.Telegram.yml
+          flatpak build-bundle repo 64Gram-fork.flatpak org.frknkrc44.Telegram
+      - name: Upload Final Flatpak
+        uses: actions/upload-artifact@v4
+        with:
+          name: 64Gram-Flatpak
+          path: 64Gram-fork.flatpak

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,12 +1,12 @@
----
 name: Flatpak Packager
+
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
   workflow_run:
-    workflows:
-      - Linux
+    workflows: ["Linux"]
     types:
       - completed
+
 jobs:
   flatpak:
     name: Package 64Gram
@@ -18,6 +18,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Checkout Repository Assets
+        uses: actions/checkout@v6
+
       - name: Download Latest Binary Artifact
         uses: dawidd6/action-download-artifact@v6
         with:
@@ -26,9 +30,9 @@ jobs:
           name: Telegram
           repo: frknkrc44/tdesktop-x64
           workflow_conclusion: success
+
       - name: Prepare Assets
         run: |
-          curl -L https://upload.wikimedia.org/wikipedia/commons/8/82/Telegram_logo.svg -o icon.svg
           cat <<EOT > org.frknkrc44.Telegram.desktop
           [Desktop Entry]
           Name=64Gram
@@ -44,6 +48,7 @@ jobs:
           StartupWMClass=Telegram
           MimeType=x-scheme-handler/tg;
           EOT
+
       - name: Create Flatpak Manifest
         run: |
           cat <<EOF > org.frknkrc44.Telegram.yml
@@ -70,25 +75,27 @@ jobs:
             - name: telegram-installer
               buildsystem: simple
               build-commands:
-                - mkdir -p /app/bin /app/share/applications /app/share/icons/hicolor/scalable/apps/
+                - mkdir -p /app/bin /app/share/applications /app/share/icons/hicolor/512x512/apps/
                 - cp Telegram /app/bin/Telegram
                 - chmod +x /app/bin/Telegram
-                - cp icon.svg /app/share/icons/hicolor/scalable/apps/org.frknkrc44.Telegram.svg
+                - cp icon512.png /app/share/icons/hicolor/512x512/apps/org.frknkrc44.Telegram.png
                 - cp org.frknkrc44.Telegram.desktop /app/share/applications/org.frknkrc44.Telegram.desktop
               sources:
                 - type: file
                   path: Telegram
                 - type: file
-                  path: icon.svg
+                  path: Telegram/Resources/art/icon512.png
                 - type: file
                   path: org.frknkrc44.Telegram.desktop
           EOF
+
       - name: Build Flatpak Bundle
         run: |
           flatpak-builder --user --install-deps-from=flathub --disable-rofiles-fuse --force-clean --repo=repo build_dir org.frknkrc44.Telegram.yml
           flatpak build-bundle repo 64Gram-fork.flatpak org.frknkrc44.Telegram
+
       - name: Upload Final Flatpak
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 64Gram-Flatpak
           path: 64Gram-fork.flatpak


### PR DESCRIPTION
This workflow is simple and a bit rough, it just takes the latest binary from the "Linux" workflow and wraps it in a flatpak. It's based on the Telegram Desktop one on Flathub but it's a simpler approach. I used this in my fork and it works, the difference is that it has a new package name and everything here. Feel free to edit whatever you want.

I haven't been able to test this version of the workflow because I don't have access to GitHub Actions.