### PR TITLE
Add 0 recent stickers feature

### DIFF
--- a/Telegram/SourceFiles/boxes/enhanced_options_box.cpp
+++ b/Telegram/SourceFiles/boxes/enhanced_options_box.cpp
@@ -383,7 +383,7 @@ void RecentDisplayLimitController::prepare() {
 
 	_optionGroup = std::make_shared<Ui::RadiobuttonGroup>(GetEnhancedInt("recent_display_limit"));
 
-	for (int i = 0; i <= 5; i++) {
+	for (int i = 0; i <= 6; i++) {
 		const auto button = Ui::CreateChild<Ui::Radiobutton>(
 				this,
 				_optionGroup,
@@ -399,6 +399,8 @@ void RecentDisplayLimitController::prepare() {
 
 QString RecentDisplayLimitController::Label(int limit) {
 	switch (limit) {
+		case 0:
+			return QString("0");
 		case 1:
 			return QString("40");
 		case 2:
@@ -409,6 +411,7 @@ QString RecentDisplayLimitController::Label(int limit) {
 			return QString("100");
 		case 5:
 			return QString("120");
+		case 6:
 		default:
 			return tr::lng_settings_recent_display_limit_default(tr::now);
 	}

--- a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
@@ -2625,7 +2625,7 @@ void StickersListWidget::refreshRecent() {
 }
 
 uint16_t getRecentDisplayLimit() {
-	int limit = GetEnhancedInt("recent_display_limit");
+	const auto limit = GetEnhancedInt("recent_display_limit");
 	switch (limit) {
 		case 0: return 0;
 		case 1: return 40;
@@ -2633,8 +2633,7 @@ uint16_t getRecentDisplayLimit() {
 		case 3: return 80;
 		case 4: return 100;
 		case 5: return 120;
-		case 6: return 20;
-		default: return 20;
+		default: return kRecentDisplayLimit;
 	}
 }
 

--- a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
@@ -2627,12 +2627,14 @@ void StickersListWidget::refreshRecent() {
 uint16_t getRecentDisplayLimit() {
 	int limit = GetEnhancedInt("recent_display_limit");
 	switch (limit) {
+		case 0: return 0;
 		case 1: return 40;
 		case 2: return 60;
 		case 3: return 80;
 		case 4: return 100;
 		case 5: return 120;
-		default: return kRecentDisplayLimit;
+		case 6: return 20;
+		default: return 20;
 	}
 }
 

--- a/Telegram/SourceFiles/core/enhanced_settings.cpp
+++ b/Telegram/SourceFiles/core/enhanced_settings.cpp
@@ -207,6 +207,19 @@ namespace EnhancedSettings {
 			}
 		});
 
+		ReadOption(settings, "recent_display_limit", [&](auto v) {
+			if (v.isDouble()) {
+				int value = v.toInt();
+				if (value < 0) {
+					gEnhancedOptions.insert("recent_display_limit", 6);
+				} else if (value > 6) {
+					gEnhancedOptions.insert("recent_display_limit", 6);
+				} else {
+					gEnhancedOptions.insert("recent_display_limit", value);
+				}
+			}
+		});
+
 		ReadStringOption(settings, "radio_controller", [&](auto v) {
 			if (v.isEmpty()) {
 				SetEnhancedValue("radio_controller", "http://localhost:2468");
@@ -320,7 +333,7 @@ namespace EnhancedSettings {
 		settings.insert(qsl("translate_to_tc"), false);
 		settings.insert(qsl("show_similar_on_joined"), false);
 		settings.insert(qsl("hide_stories"), false);
-		settings.insert(qsl("recent_display_limit"), 20);
+		settings.insert(qsl("recent_display_limit"), 6);
 		settings.insert(qsl("screenshot_mode"), false);
 		settings.insert(qsl("hide_star_ratings"), false);
 


### PR DESCRIPTION
This adds a "0" value to the recent stickers settings menu, which basically makes it so you don't see them anymore once you turn it on. This feature is totally inspired by Momogram.